### PR TITLE
feat(inventory, atencion): lot duplicate validation + editable detail…

### DIFF
--- a/docs/superpowers/plans/2026-07-08-stock-adjustment-on-attention-edit.md
+++ b/docs/superpowers/plans/2026-07-08-stock-adjustment-on-attention-edit.md
@@ -1,0 +1,618 @@
+# Stock Adjustment on Attention Edit — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** When a user edits medication details (Lote, Cantidad) in an existing attention, properly adjust lot stock and create audit trail movements.
+
+**Architecture:** Create a new `EditarAtencionUseCase` that follows the existing reversal pattern (see `EditarMovimientoUseCase`). The approach: reverse old stock effects → apply new stock effects → update detail records → create movement records. Also fix `eliminarAtencion()` to properly reverse stock.
+
+**Tech Stack:** Java, JDBC, TransactionManager, existing repository infrastructure
+
+## Current State Analysis
+
+**The Problem:**
+- `updateDetalle()` in `JdbcAtencionRepository` only updates the `atencion_detalles` row — NO stock adjustment
+- `deleteAtencion()` in `JdbcAtencionRepository` only deletes records — NO stock restoration
+- Movements created during attention creation are NEVER cleaned up
+
+**Data Flow (Current — Broken):**
+```
+Edit modal → onSaveEditar() → atencionAdapter.editarDetalle() → UPDATE atencion_detalles (no stock change)
+Delete → onEliminarAtencion() → atencionAdapter.eliminarAtencion() → DELETE records (no stock change)
+```
+
+**Data Flow (Target — Fixed):**
+```
+Edit modal → onSaveEditar() → atencionAdapter.editarAtencionCompleta() → EditarAtencionUseCase
+  → transaction:
+    1. Load original details
+    2. For each changed detail: reverse old stock, apply new stock
+    3. Update detail records
+    4. Create reversal + new exit movement records
+    5. Update parent atencion (receta, medico)
+```
+
+## Global Constraints
+
+- Follow existing hexagonal architecture patterns
+- Use `TransactionManager.execute()` for all multi-step DB operations
+- Use existing `loteRepository.aumentarStock()` / `reducirStock()` methods
+- Movement records must use `TipoMovimientoEnum.SALIDA` + `MotivoMovimientoEnum.ATENCION`
+- Stock validation: check `cantidad >= requested` before reducing (existing `reducirStock` does this)
+- All changes must compile with `./mvnw compile -q`
+
+---
+
+## File Map
+
+| File | Action | Purpose |
+|------|--------|---------|
+| `EditarAtencionUseCase.java` | **Create** | New use case for editing attention with stock adjustment |
+| `AtencionAdapter.java` | Modify | Add `editarAtencionCompleta()` method that calls the new use case |
+| `AtencionController.java` | Modify | Store original details, call new adapter method |
+| `eliminarAtencion()` in `AtencionAdapter.java` | Modify | Add stock reversal before deletion |
+| `JdbcAtencionRepository.java` | Modify | Add `deleteDetallesByAtencionId()` method |
+
+---
+
+### Task 1: Create `EditarAtencionUseCase`
+
+**Files:**
+- Create: `src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EditarAtencionUseCase.java`
+
+**Interfaces:**
+- Consumes: `AtencionRepository`, `LoteRepository`, `MovimientoRepository`, `TransactionManager`
+- Produces: `editarAtencion(Atencion, List<AtencionDetalle> originales, List<AtencionDetalle> nuevas)` → `String`
+
+- [ ] **Step 1: Create the use case class**
+
+```java
+package com.utp.meditrackapp.domain.services.dispensacion;
+
+import com.utp.meditrackapp.application.config.TransactionManager;
+import com.utp.meditrackapp.core.models.enums.MotivoMovimientoEnum;
+import com.utp.meditrackapp.core.models.enums.TipoMovimientoEnum;
+import com.utp.meditrackapp.domain.entities.Atencion;
+import com.utp.meditrackapp.domain.entities.AtencionDetalle;
+import com.utp.meditrackapp.domain.entities.Movimiento;
+import com.utp.meditrackapp.domain.ports.out.AtencionRepository;
+import com.utp.meditrackapp.domain.ports.out.LoteRepository;
+import com.utp.meditrackapp.domain.ports.out.MovimientoRepository;
+
+import java.util.List;
+
+/**
+ * Caso de uso: Editar una atención existente ajustando stock y creando movimientos de auditoría.
+ * Invierte el efecto de stock original y aplica el nuevo efecto.
+ */
+public class EditarAtencionUseCase {
+    private final AtencionRepository atencionRepository;
+    private final LoteRepository loteRepository;
+    private final MovimientoRepository movimientoRepository;
+    private final TransactionManager transactionManager;
+
+    public EditarAtencionUseCase(AtencionRepository atencionRepository,
+                                  LoteRepository loteRepository,
+                                  MovimientoRepository movimientoRepository,
+                                  TransactionManager transactionManager) {
+        this.atencionRepository = atencionRepository;
+        this.loteRepository = loteRepository;
+        this.movimientoRepository = movimientoRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Edita una atención ajustando stock y detalles.
+     *
+     * @param atencion   La atención con campos actualizados (receta, médico)
+     * @param originales Los detalles originales (antes de la edición)
+     * @param nuevas     Los detalles nuevos (después de la edición)
+     * @return "OK" si éxito, o mensaje de error
+     */
+    public String editarAtencion(Atencion atencion, List<AtencionDetalle> originales, List<AtencionDetalle> nuevas) {
+        if (atencion == null || atencion.getId() == null) {
+            return "La atención es inválida.";
+        }
+        if (nuevas == null || nuevas.isEmpty()) {
+            return "Debe haber al menos un medicamento.";
+        }
+
+        // Validate new details
+        for (AtencionDetalle det : nuevas) {
+            String val = det.validate();
+            if (val != null) return val;
+        }
+
+        try {
+            transactionManager.execute(conn -> {
+                // 1. Update parent atencion (receta, medico)
+                atencionRepository.updateAtencion(atencion);
+
+                // 2. Delete old details
+                atencionRepository.deleteDetallesByAtencionId(conn, atencion.getId());
+
+                // 3. For each original detail: reverse stock + create reversal movement
+                for (AtencionDetalle orig : originales) {
+                    loteRepository.aumentarStock(conn, orig.getLoteId(), orig.getCantidadEntregada());
+
+                    Movimiento reversa = new Movimiento();
+                    reversa.setTipoId(TipoMovimientoEnum.ENTRADA.getId());
+                    reversa.setMotivoId(MotivoMovimientoEnum.ATENCION.getId());
+                    reversa.setSedeId(atencion.getSedeId());
+                    reversa.setUsuarioId(atencion.getUsuarioId());
+                    reversa.setLoteId(orig.getLoteId());
+                    reversa.setCantidad(orig.getCantidadEntregada());
+                    reversa.setObservacion("Reversa por edición - Receta: " + atencion.getNumeroReceta());
+                    movimientoRepository.save(conn, reversa);
+                }
+
+                // 4. For each new detail: save detail + reduce stock + create exit movement
+                for (AtencionDetalle det : nuevas) {
+                    det.setAtencionId(atencion.getId());
+                    atencionRepository.saveDetalle(conn, det);
+
+                    loteRepository.reducirStock(conn, det.getLoteId(), det.getCantidadEntregada());
+
+                    Movimiento salida = new Movimiento();
+                    salida.setTipoId(TipoMovimientoEnum.SALIDA.getId());
+                    salida.setMotivoId(MotivoMovimientoEnum.ATENCION.getId());
+                    salida.setSedeId(atencion.getSedeId());
+                    salida.setUsuarioId(atencion.getUsuarioId());
+                    salida.setLoteId(det.getLoteId());
+                    salida.setCantidad(det.getCantidadEntregada());
+                    salida.setObservacion("Atención Médica (editada) - Receta: " + atencion.getNumeroReceta());
+                    movimientoRepository.save(conn, salida);
+                }
+            });
+            return "OK";
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EditarAtencionUseCase.java
+git commit -m "feat(inventory): add EditarAtencionUseCase with stock reversal logic"
+```
+
+---
+
+### Task 2: Add `deleteDetallesByAtencionId()` to Repository
+
+**Files:**
+- Modify: `src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java:40`
+- Modify: `src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java:307`
+
+**Interfaces:**
+- Produces: `deleteDetallesByAtencionId(Connection conn, String atencionId)` → `void`
+
+- [ ] **Step 1: Add method to interface**
+
+In `AtencionRepository.java`, add before the closing brace:
+
+```java
+void deleteDetallesByAtencionId(java.sql.Connection conn, String atencionId);
+```
+
+- [ ] **Step 2: Implement in JdbcAtencionRepository**
+
+In `JdbcAtencionRepository.java`, add after `deleteAtencion()`:
+
+```java
+@Override
+public void deleteDetallesByAtencionId(java.sql.Connection conn, String atencionId) {
+    String sql = "DELETE FROM atencion_detalles WHERE atencion_id = ?";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        ps.setString(1, atencionId);
+        ps.executeUpdate();
+    } catch (SQLException e) {
+        throw new RuntimeException("Error al eliminar detalles: " + e.getMessage(), e);
+    }
+}
+```
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java
+git commit -m "feat(inventory): add deleteDetallesByAtencionId to repository"
+```
+
+---
+
+### Task 3: Wire `EditarAtencionUseCase` into `AtencionAdapter`
+
+**Files:**
+- Modify: `src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java:40-60`
+
+**Interfaces:**
+- Consumes: `EditarAtencionUseCase` (from Task 1)
+- Produces: `editarAtencionCompleta(Atencion, List<AtencionDetalle>, List<AtencionDetalle>)` → `String`
+
+- [ ] **Step 1: Add field and constructor wiring**
+
+In `AtencionAdapter.java`, find the field declarations and add:
+
+```java
+private final EditarAtencionUseCase editarAtencionUseCase;
+```
+
+In the constructor, add initialization:
+
+```java
+this.editarAtencionUseCase = new EditarAtencionUseCase(
+    atencionRepository,
+    new JdbcLoteRepository(),
+    new JdbcMovimientoRepository(),
+    new TransactionManager()
+);
+```
+
+- [ ] **Step 2: Add the new method**
+
+In `AtencionAdapter.java`, add after `editarAtencion()`:
+
+```java
+public String editarAtencionCompleta(Atencion atencion, List<AtencionDetalle> originales, List<AtencionDetalle> nuevas) {
+    return editarAtencionUseCase.editarAtencion(atencion, originales, nuevas);
+}
+```
+
+- [ ] **Step 3: Add imports**
+
+Add to the imports section:
+
+```java
+import com.utp.meditrackapp.domain.services.dispensacion.EditarAtencionUseCase;
+import com.utp.meditrackapp.infrastructure.persistence.jdbc.JdbcMovimientoRepository;
+import com.utp.meditrackapp.application.config.TransactionManager;
+import java.util.List;
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java
+git commit -m "feat(inventory): wire EditarAtencionUseCase into AtencionAdapter"
+```
+
+---
+
+### Task 4: Update `AtencionController` to Use Stock-Aware Edit
+
+**Files:**
+- Modify: `src/main/java/com/utp/meditrackapp/features/attentions/ui/AtencionController.java:68-72,290-332`
+
+**Interfaces:**
+- Consumes: `atencionAdapter.editarAtencionCompleta()` (from Task 3)
+- Produces: Proper stock adjustment on save
+
+- [ ] **Step 1: Add field to store original details**
+
+In `AtencionController.java`, find the field declarations and add:
+
+```java
+private List<AtencionDetalle> originalDetalles = new ArrayList<>();
+```
+
+- [ ] **Step 2: Update `onEditarAtencion()` to store original details**
+
+Find `onEditarAtencion()` and update the detail loading section. Replace the try-catch block that loads details:
+
+```java
+// Load details for editing
+editDetalleItems.clear();
+originalDetalles.clear();
+try {
+    List<AtencionDetalle> detalles = atencionAdapter.buscarDetallesAtencion(atencion.getId());
+    originalDetalles.addAll(detalles);  // Store originals for stock reversal
+    Usuario user = sessionManager.getCurrentUser();
+    String sedeId = user != null ? user.getSedeId() : null;
+    for (AtencionDetalle det : detalles) {
+        EditableDetalleRow row = new EditableDetalleRow();
+        row.detalleIdProperty().set(det.getId());
+        row.productoIdProperty().set(det.getProductoId());
+        row.productoNombreProperty().set(det.getProductoNombre());
+        row.loteIdProperty().set(det.getLoteId());
+        row.loteNumeroProperty().set(det.getLoteNumero());
+        row.cantidadEntregadaProperty().set(det.getCantidadEntregada());
+        // Load available lots for this product
+        if (det.getProductoId() != null && sedeId != null) {
+            List<Lote> lotes = atencionAdapter.listarLotesFefo(sedeId, det.getProductoId());
+            row.setLotesDisponibles(FXCollections.observableArrayList(lotes));
+        }
+        editDetalleItems.add(row);
+    }
+} catch (Exception e) {
+    e.printStackTrace();
+}
+```
+
+- [ ] **Step 3: Update `onSaveEditar()` to use stock-aware method**
+
+Replace the entire `onSaveEditar()` method:
+
+```java
+@FXML
+protected void onSaveEditar() {
+    if (editingAtencion == null) return;
+    String receta = txtEditReceta.getText();
+    if (receta == null || receta.isBlank()) {
+        showAlert(Alert.AlertType.WARNING, "Validación", "El número de receta es obligatorio.");
+        return;
+    }
+    editingAtencion.setNumeroReceta(receta.trim());
+    editingAtencion.setMedico(txtEditMedico.getText() != null ? txtEditMedico.getText().trim() : "");
+
+    // Build new details list from edit table
+    List<AtencionDetalle> nuevas = new ArrayList<>();
+    for (EditableDetalleRow row : editDetalleItems) {
+        if (row.getLoteId() == null || row.getLoteId().isBlank()) {
+            showAlert(Alert.AlertType.WARNING, "Validación",
+                "Seleccione un lote para: " + row.getProductoNombre());
+            return;
+        }
+        if (row.getCantidadEntregada() <= 0) {
+            showAlert(Alert.AlertType.WARNING, "Validación",
+                "Ingrese una cantidad válida para: " + row.getProductoNombre());
+            return;
+        }
+        AtencionDetalle det = new AtencionDetalle();
+        det.setId(row.getDetalleId());
+        det.setLoteId(row.getLoteId());
+        det.setCantidadEntregada(row.getCantidadEntregada());
+        det.setProductoId(row.getProductoId());
+        det.setProductoNombre(row.getProductoNombre());
+        nuevas.add(det);
+    }
+
+    try {
+        String result = atencionAdapter.editarAtencionCompleta(editingAtencion, originalDetalles, nuevas);
+        if ("OK".equals(result)) {
+            showAlert(Alert.AlertType.INFORMATION, "Éxito", "Atención actualizada correctamente.");
+            modalEditar.setVisible(false);
+            editDetalleItems.clear();
+            originalDetalles.clear();
+            editingAtencion = null;
+            onBuscarAtenciones();
+        } else {
+            showAlert(Alert.AlertType.ERROR, "Error", result);
+        }
+    } catch (Exception e) {
+        showAlert(Alert.AlertType.ERROR, "Error", "No se pudo actualizar: " + e.getMessage());
+    }
+}
+```
+
+- [ ] **Step 4: Update `onCloseEditar()` to clear originals**
+
+```java
+@FXML
+protected void onCloseEditar() {
+    modalEditar.setVisible(false);
+    editDetalleItems.clear();
+    originalDetalles.clear();
+    editingAtencion = null;
+}
+```
+
+- [ ] **Step 5: Verify compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/com/utp/meditrackapp/features/attentions/ui/AtencionController.java
+git commit -m "feat(inventory): use stock-aware edit in AtencionController"
+```
+
+---
+
+### Task 5: Fix `eliminarAtencion()` to Reverse Stock
+
+**Files:**
+- Modify: `src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java:118-121`
+- Modify: `src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java`
+- Modify: `src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java`
+
+**Interfaces:**
+- Produces: `eliminarAtencionCompleta(String atencionId, String sedeId, String usuarioId)` → `String`
+
+- [ ] **Step 1: Add `deleteMovimientosByLotes()` to repository**
+
+In `AtencionRepository.java`, add:
+
+```java
+void deleteMovimientosByAtencionId(java.sql.Connection conn, String atencionId);
+```
+
+In `JdbcAtencionRepository.java`, add implementation. This requires joining with `atencion_detalles` to find the movement records:
+
+```java
+@Override
+public void deleteMovimientosByAtencionId(java.sql.Connection conn, String atencionId) {
+    String sql = "DELETE FROM movimientos WHERE lote_id IN " +
+        "(SELECT lote_id FROM atencion_detalles WHERE atencion_id = ?) " +
+        "AND observacion LIKE ?";
+    try (PreparedStatement ps = conn.prepareStatement(sql)) {
+        ps.setString(1, atencionId);
+        ps.setString(2, "%Receta:%");
+        ps.executeUpdate();
+    } catch (SQLException e) {
+        throw new RuntimeException("Error al eliminar movimientos: " + e.getMessage(), e);
+    }
+}
+```
+
+- [ ] **Step 2: Create `EliminarAtencionUseCase`**
+
+Create: `src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EliminarAtencionUseCase.java`
+
+```java
+package com.utp.meditrackapp.domain.services.dispensacion;
+
+import com.utp.meditrackapp.application.config.TransactionManager;
+import com.utp.meditrackapp.domain.entities.AtencionDetalle;
+import com.utp.meditrackapp.domain.ports.out.AtencionRepository;
+import com.utp.meditrackapp.domain.ports.out.LoteRepository;
+import com.utp.meditrackapp.domain.ports.out.MovimientoRepository;
+
+import java.util.List;
+
+/**
+ * Caso de uso: Eliminar una atención devolviendo stock y limpiando movimientos.
+ */
+public class EliminarAtencionUseCase {
+    private final AtencionRepository atencionRepository;
+    private final LoteRepository loteRepository;
+    private final MovimientoRepository movimientoRepository;
+    private final TransactionManager transactionManager;
+
+    public EliminarAtencionUseCase(AtencionRepository atencionRepository,
+                                    LoteRepository loteRepository,
+                                    MovimientoRepository movimientoRepository,
+                                    TransactionManager transactionManager) {
+        this.atencionRepository = atencionRepository;
+        this.loteRepository = loteRepository;
+        this.movimientoRepository = movimientoRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    public String eliminar(String atencionId, String sedeId, String usuarioId) {
+        if (atencionId == null || atencionId.isEmpty()) {
+            return "ID de atención inválido.";
+        }
+
+        try {
+            transactionManager.execute(conn -> {
+                // 1. Load details to know what stock to return
+                List<AtencionDetalle> detalles = atencionRepository.findDetallesByAtencionId(atencionId);
+
+                // 2. Return stock for each detail
+                for (AtencionDetalle det : detalles) {
+                    loteRepository.aumentarStock(conn, det.getLoteId(), det.getCantidadEntregada());
+                }
+
+                // 3. Delete movement records linked to this attention
+                atencionRepository.deleteMovimientosByAtencionId(conn, atencionId);
+
+                // 4. Delete detail records
+                atencionRepository.deleteDetallesByAtencionId(conn, atencionId);
+
+                // 5. Delete parent attention
+                atencionRepository.deleteAtencion(atencionId);
+            });
+            return "OK";
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Wire into AtencionAdapter**
+
+In `AtencionAdapter.java`, add field:
+
+```java
+private final EliminarAtencionUseCase eliminarAtencionUseCase;
+```
+
+In constructor, add:
+
+```java
+this.eliminarAtencionUseCase = new EliminarAtencionUseCase(
+    atencionRepository,
+    new JdbcLoteRepository(),
+    new JdbcMovimientoRepository(),
+    new TransactionManager()
+);
+```
+
+Replace `eliminarAtencion()`:
+
+```java
+public String eliminarAtencion(String atencionId) {
+    Usuario user = SessionManager.getInstance().getCurrentUser();
+    return eliminarAtencionUseCase.eliminar(atencionId, user.getSedeId(), user.getId());
+}
+```
+
+Add import:
+
+```java
+import com.utp.meditrackapp.domain.services.dispensacion.EliminarAtencionUseCase;
+import com.utp.meditrackapp.core.config.SessionManager;
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EliminarAtencionUseCase.java src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java
+git commit -m "feat(inventory): fix eliminarAtencion to reverse stock and clean movements"
+```
+
+---
+
+### Task 6: Final Verification
+
+- [ ] **Step 1: Full compilation**
+
+Run: `./mvnw compile -q`
+Expected: No errors
+
+- [ ] **Step 2: Manual test scenarios**
+
+Test the following in the app:
+
+1. **Edit quantity only:** Create attention with 5 units from Lot A. Edit to 3 units. Verify Lot A stock increased by 2.
+2. **Edit lot only:** Create attention with 3 units from Lot A. Change to Lot B. Verify Lot A +3, Lot B -3.
+3. **Edit both:** Create attention with 5 from Lot A. Change to Lot B with 3 units. Verify Lot A +5, Lot B -3.
+4. **Delete attention:** Create attention, then delete it. Verify all lots restored and movements cleaned.
+5. **Check inventory tab:** Movements table should show reversal + new exit records.
+
+- [ ] **Step 3: Commit final state**
+
+```bash
+git add -A
+git commit -m "feat(inventory): complete stock adjustment on attention edit/delete"
+```
+
+---
+
+## Stock Adjustment Logic Summary
+
+| Scenario | Stock Action | Movement Records |
+|----------|-------------|-----------------|
+| Quantity changed (5→3, same lot) | Lot: +2 (return difference) | 1 reversal (ENTRADA, qty 2) |
+| Lot changed (A→B, same qty) | Lot A: +qty, Lot B: -qty | 1 reversal (ENTRADA, A) + 1 exit (SALIDA, B) |
+| Both changed (A/5 → B/3) | Lot A: +5, Lot B: -3 | 1 reversal (ENTRADA, A/5) + 1 exit (SALIDA, B/3) |
+| Detail removed | Lot: +original qty | 1 reversal (ENTRADA, original qty) |
+| Detail added | Lot: -new qty | 1 exit (SALIDA, new qty) |
+| Attention deleted | All lots: +original qty each | All movements deleted |

--- a/src/main/java/com/utp/meditrackapp/domain/entities/AtencionDetalle.java
+++ b/src/main/java/com/utp/meditrackapp/domain/entities/AtencionDetalle.java
@@ -11,6 +11,7 @@ public class AtencionDetalle {
     private int cantidadEntregada;
 
     // Transient fields for UI
+    private String productoId;
     private String productoNombre;
     private String loteNumero;
     private String fechaVencimiento;
@@ -59,6 +60,9 @@ public class AtencionDetalle {
 
     public int getCantidadEntregada() { return cantidadEntregada; }
     public void setCantidadEntregada(int cantidadEntregada) { this.cantidadEntregada = cantidadEntregada; }
+
+    public String getProductoId() { return productoId; }
+    public void setProductoId(String productoId) { this.productoId = productoId; }
 
     public String getProductoNombre() { return productoNombre; }
     public void setProductoNombre(String productoNombre) { this.productoNombre = productoNombre; }

--- a/src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java
+++ b/src/main/java/com/utp/meditrackapp/domain/ports/out/AtencionRepository.java
@@ -37,5 +37,11 @@ public interface AtencionRepository {
 
     void updateAtencion(Atencion atencion);
 
+    void updateDetalle(String detalleId, String nuevoLoteId, int nuevaCantidad);
+
+    void deleteDetallesByAtencionId(java.sql.Connection conn, String atencionId);
+
+    void deleteMovimientosByAtencionId(java.sql.Connection conn, String atencionId);
+
     void deleteAtencion(String atencionId);
 }

--- a/src/main/java/com/utp/meditrackapp/domain/ports/out/LoteRepository.java
+++ b/src/main/java/com/utp/meditrackapp/domain/ports/out/LoteRepository.java
@@ -34,6 +34,11 @@ public interface LoteRepository {
     int findStockByLote(Connection conn, String loteId);
 
     /**
+     * Verifica si ya existe un lote con el número dado para el mismo producto en la misma sede.
+     */
+    boolean existsByNumeroLoteProductoSede(String numeroLote, String productoId, String sedeId);
+
+    /**
      * Versión sin Connection para operaciones simples que manejan su propia conexión.
      */
     Lote save(Lote lote);

--- a/src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EditarAtencionUseCase.java
+++ b/src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EditarAtencionUseCase.java
@@ -1,0 +1,102 @@
+package com.utp.meditrackapp.domain.services.dispensacion;
+
+import com.utp.meditrackapp.application.config.TransactionManager;
+import com.utp.meditrackapp.core.models.enums.MotivoMovimientoEnum;
+import com.utp.meditrackapp.core.models.enums.TipoMovimientoEnum;
+import com.utp.meditrackapp.domain.entities.Atencion;
+import com.utp.meditrackapp.domain.entities.AtencionDetalle;
+import com.utp.meditrackapp.domain.entities.Movimiento;
+import com.utp.meditrackapp.domain.ports.out.AtencionRepository;
+import com.utp.meditrackapp.domain.ports.out.LoteRepository;
+import com.utp.meditrackapp.domain.ports.out.MovimientoRepository;
+
+import java.util.List;
+
+/**
+ * Caso de uso: Editar una atención existente ajustando stock y creando movimientos de auditoría.
+ * Invierte el efecto de stock original y aplica el nuevo efecto.
+ */
+public class EditarAtencionUseCase {
+    private final AtencionRepository atencionRepository;
+    private final LoteRepository loteRepository;
+    private final MovimientoRepository movimientoRepository;
+    private final TransactionManager transactionManager;
+
+    public EditarAtencionUseCase(AtencionRepository atencionRepository,
+                                  LoteRepository loteRepository,
+                                  MovimientoRepository movimientoRepository,
+                                  TransactionManager transactionManager) {
+        this.atencionRepository = atencionRepository;
+        this.loteRepository = loteRepository;
+        this.movimientoRepository = movimientoRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    /**
+     * Edita una atención ajustando stock y detalles.
+     *
+     * @param atencion   La atención con campos actualizados (receta, médico)
+     * @param originales Los detalles originales (antes de la edición)
+     * @param nuevas     Los detalles nuevos (después de la edición)
+     * @return "OK" si éxito, o mensaje de error
+     */
+    public String editarAtencion(Atencion atencion, List<AtencionDetalle> originales, List<AtencionDetalle> nuevas) {
+        if (atencion == null || atencion.getId() == null) {
+            return "La atención es inválida.";
+        }
+        if (nuevas == null || nuevas.isEmpty()) {
+            return "Debe haber al menos un medicamento.";
+        }
+
+        for (AtencionDetalle det : nuevas) {
+            String val = det.validate();
+            if (val != null) return val;
+        }
+
+        try {
+            transactionManager.execute(conn -> {
+                // 1. Update parent atencion (receta, medico)
+                atencionRepository.updateAtencion(atencion);
+
+                // 2. Delete old details
+                atencionRepository.deleteDetallesByAtencionId(conn, atencion.getId());
+
+                // 3. For each original detail: reverse stock + create reversal movement
+                for (AtencionDetalle orig : originales) {
+                    loteRepository.aumentarStock(conn, orig.getLoteId(), orig.getCantidadEntregada());
+
+                    Movimiento reversa = new Movimiento();
+                    reversa.setTipoId(TipoMovimientoEnum.ENTRADA.getId());
+                    reversa.setMotivoId(MotivoMovimientoEnum.ATENCION.getId());
+                    reversa.setSedeId(atencion.getSedeId());
+                    reversa.setUsuarioId(atencion.getUsuarioId());
+                    reversa.setLoteId(orig.getLoteId());
+                    reversa.setCantidad(orig.getCantidadEntregada());
+                    reversa.setObservacion("Reversa por edición - Receta: " + atencion.getNumeroReceta());
+                    movimientoRepository.save(conn, reversa);
+                }
+
+                // 4. For each new detail: save detail + reduce stock + create exit movement
+                for (AtencionDetalle det : nuevas) {
+                    det.setAtencionId(atencion.getId());
+                    atencionRepository.saveDetalle(conn, det);
+
+                    loteRepository.reducirStock(conn, det.getLoteId(), det.getCantidadEntregada());
+
+                    Movimiento salida = new Movimiento();
+                    salida.setTipoId(TipoMovimientoEnum.SALIDA.getId());
+                    salida.setMotivoId(MotivoMovimientoEnum.ATENCION.getId());
+                    salida.setSedeId(atencion.getSedeId());
+                    salida.setUsuarioId(atencion.getUsuarioId());
+                    salida.setLoteId(det.getLoteId());
+                    salida.setCantidad(det.getCantidadEntregada());
+                    salida.setObservacion("Atención Médica (editada) - Receta: " + atencion.getNumeroReceta());
+                    movimientoRepository.save(conn, salida);
+                }
+            });
+            return "OK";
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EliminarAtencionUseCase.java
+++ b/src/main/java/com/utp/meditrackapp/domain/services/dispensacion/EliminarAtencionUseCase.java
@@ -1,0 +1,59 @@
+package com.utp.meditrackapp.domain.services.dispensacion;
+
+import com.utp.meditrackapp.application.config.TransactionManager;
+import com.utp.meditrackapp.domain.entities.AtencionDetalle;
+import com.utp.meditrackapp.domain.ports.out.AtencionRepository;
+import com.utp.meditrackapp.domain.ports.out.LoteRepository;
+import com.utp.meditrackapp.domain.ports.out.MovimientoRepository;
+
+import java.util.List;
+
+/**
+ * Caso de uso: Eliminar una atención devolviendo stock y limpiando movimientos.
+ */
+public class EliminarAtencionUseCase {
+    private final AtencionRepository atencionRepository;
+    private final LoteRepository loteRepository;
+    private final MovimientoRepository movimientoRepository;
+    private final TransactionManager transactionManager;
+
+    public EliminarAtencionUseCase(AtencionRepository atencionRepository,
+                                    LoteRepository loteRepository,
+                                    MovimientoRepository movimientoRepository,
+                                    TransactionManager transactionManager) {
+        this.atencionRepository = atencionRepository;
+        this.loteRepository = loteRepository;
+        this.movimientoRepository = movimientoRepository;
+        this.transactionManager = transactionManager;
+    }
+
+    public String eliminar(String atencionId, String sedeId, String usuarioId) {
+        if (atencionId == null || atencionId.isEmpty()) {
+            return "ID de atención inválido.";
+        }
+
+        try {
+            transactionManager.execute(conn -> {
+                // 1. Load details to know what stock to return
+                List<AtencionDetalle> detalles = atencionRepository.findDetallesByAtencionId(atencionId);
+
+                // 2. Return stock for each detail
+                for (AtencionDetalle det : detalles) {
+                    loteRepository.aumentarStock(conn, det.getLoteId(), det.getCantidadEntregada());
+                }
+
+                // 3. Delete movement records linked to this attention
+                atencionRepository.deleteMovimientosByAtencionId(conn, atencionId);
+
+                // 4. Delete detail records
+                atencionRepository.deleteDetallesByAtencionId(conn, atencionId);
+
+                // 5. Delete parent attention
+                atencionRepository.deleteAtencion(atencionId);
+            });
+            return "OK";
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
+    }
+}

--- a/src/main/java/com/utp/meditrackapp/domain/services/inventario/RegistrarMovimientoUseCase.java
+++ b/src/main/java/com/utp/meditrackapp/domain/services/inventario/RegistrarMovimientoUseCase.java
@@ -110,6 +110,12 @@ public class RegistrarMovimientoUseCase {
         if (lote.getSedeId() == null || lote.getSedeId().isEmpty()) return "La sede es obligatoria.";
         if (cantidad <= 0) return "La cantidad debe ser mayor a cero.";
         if (lote.getFechaVencimiento() == null) return "La fecha de vencimiento es obligatoria.";
+        if (lote.getNumeroLote() == null || lote.getNumeroLote().isBlank()) return "El N° de Lote es obligatorio.";
+        if (loteRepository.existsByNumeroLoteProductoSede(
+                lote.getNumeroLote().trim(), lote.getProductoId(), lote.getSedeId())) {
+            return "Ya existe un lote con el N° \"" + lote.getNumeroLote().trim()
+                    + "\" para este producto en esta sede. Verifique el número e intente nuevamente.";
+        }
         return null;
     }
 }

--- a/src/main/java/com/utp/meditrackapp/features/attentions/ui/AtencionController.java
+++ b/src/main/java/com/utp/meditrackapp/features/attentions/ui/AtencionController.java
@@ -26,6 +26,10 @@ import org.kordamp.ikonli.javafx.FontIcon;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
 import java.util.stream.Collectors;
+import javafx.beans.property.SimpleStringProperty;
+import javafx.beans.property.SimpleIntegerProperty;
+import javafx.beans.property.StringProperty;
+import javafx.beans.property.IntegerProperty;
 
 public class AtencionController {
 
@@ -64,13 +68,19 @@ public class AtencionController {
     @FXML private StackPane modalEditar;
     @FXML private Label lblEditarSub;
     @FXML private TextField txtEditReceta, txtEditMedico;
+    @FXML private TableView<EditableDetalleRow> tableEditDetalle;
+    @FXML private TableColumn<EditableDetalleRow, String> colEditProducto;
+    @FXML private TableColumn<EditableDetalleRow, String> colEditLote;
+    @FXML private TableColumn<EditableDetalleRow, Number> colEditCantidad;
 
     private final ObservableList<AtencionDetalle> basketItems = FXCollections.observableArrayList();
     private final ObservableList<Atencion> historialItems = FXCollections.observableArrayList();
     private final ObservableList<AtencionDetalle> detalleItems = FXCollections.observableArrayList();
+    private final ObservableList<EditableDetalleRow> editDetalleItems = FXCollections.observableArrayList();
     private Paciente currentPacienteDisp;
     private Atencion editingAtencion;
     private String recetaGenerada;
+    private List<AtencionDetalle> originalDetalles = new ArrayList<>();
 
     private static final DateTimeFormatter FMT_FECHA = DateTimeFormatter.ofPattern("dd/MM/yyyy HH:mm");
 
@@ -166,6 +176,72 @@ public class AtencionController {
         colDetVencimiento.setCellValueFactory(new PropertyValueFactory<>("fechaVencimiento"));
         colDetCantidad.setCellValueFactory(new PropertyValueFactory<>("cantidadEntregada"));
         tableDetalle.setItems(detalleItems);
+
+        // Edit modal detail table
+        colEditProducto.setCellValueFactory(cd -> cd.getValue().productoNombreProperty());
+        colEditCantidad.setCellValueFactory(cd -> cd.getValue().cantidadEntregadaProperty());
+        colEditLote.setCellValueFactory(cd -> cd.getValue().loteNumeroProperty());
+        colEditLote.setCellFactory(param -> new TableCell<>() {
+            private ComboBox<Lote> combo;
+            @Override
+            protected void updateItem(String item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty) {
+                    setGraphic(null);
+                } else {
+                    EditableDetalleRow row = getTableView().getItems().get(getIndex());
+                    combo = new ComboBox<>(row.getLotesDisponibles());
+                    combo.setConverter(new StringConverter<>() {
+                        @Override public String toString(Lote l) {
+                            if (l == null) return "";
+                            DateTimeFormatter fmt = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+                            String vence = l.getFechaVencimiento() != null ? l.getFechaVencimiento().format(fmt) : "N/D";
+                            return l.getNumeroLote() + " — Vence: " + vence + " — Stock: " + l.getCantidad();
+                        }
+                        @Override public Lote fromString(String s) { return null; }
+                    });
+                    // Select current lot
+                    for (Lote l : row.getLotesDisponibles()) {
+                        if (l.getId().equals(row.getLoteId())) {
+                            combo.getSelectionModel().select(l);
+                            break;
+                        }
+                    }
+                    combo.valueProperty().addListener((obs, oldVal, newVal) -> {
+                        if (newVal != null) {
+                            row.loteIdProperty().set(newVal.getId());
+                            row.loteNumeroProperty().set(newVal.getNumeroLote());
+                        }
+                    });
+                    combo.setMaxWidth(Double.MAX_VALUE);
+                    setGraphic(combo);
+                }
+            }
+        });
+        colEditCantidad.setCellFactory(param -> new TableCell<>() {
+            private TextField tf;
+            @Override
+            protected void updateItem(Number item, boolean empty) {
+                super.updateItem(item, empty);
+                if (empty) {
+                    setGraphic(null);
+                } else {
+                    tf = new TextField(item != null ? String.valueOf(item.intValue()) : "0");
+                    tf.setMaxWidth(80);
+                    tf.textProperty().addListener((obs, oldVal, newVal) -> {
+                        try {
+                            int qty = Integer.parseInt(newVal);
+                            if (qty > 0) {
+                                EditableDetalleRow row = getTableView().getItems().get(getIndex());
+                                row.cantidadEntregadaProperty().set(qty);
+                            }
+                        } catch (NumberFormatException ignored) {}
+                    });
+                    setGraphic(tf);
+                }
+            }
+        });
+        tableEditDetalle.setItems(editDetalleItems);
     }
 
     private void setupProductCombo() {
@@ -301,12 +377,42 @@ public class AtencionController {
         txtEditMedico.setText(atencion.getMedico() != null ? atencion.getMedico() : "");
         String fecha = atencion.getFechaAtencion() != null ? atencion.getFechaAtencion().format(FMT_FECHA) : "N/D";
         lblEditarSub.setText("Atención del " + fecha);
+
+        // Load details for editing
+        editDetalleItems.clear();
+        originalDetalles.clear();
+        try {
+            List<AtencionDetalle> detalles = atencionAdapter.buscarDetallesAtencion(atencion.getId());
+            originalDetalles.addAll(detalles);
+            Usuario user = sessionManager.getCurrentUser();
+            String sedeId = user != null ? user.getSedeId() : null;
+            for (AtencionDetalle det : detalles) {
+                EditableDetalleRow row = new EditableDetalleRow();
+                row.detalleIdProperty().set(det.getId());
+                row.productoIdProperty().set(det.getProductoId());
+                row.productoNombreProperty().set(det.getProductoNombre());
+                row.loteIdProperty().set(det.getLoteId());
+                row.loteNumeroProperty().set(det.getLoteNumero());
+                row.cantidadEntregadaProperty().set(det.getCantidadEntregada());
+                // Load available lots for this product
+                if (det.getProductoId() != null && sedeId != null) {
+                    List<Lote> lotes = atencionAdapter.listarLotesFefo(sedeId, det.getProductoId());
+                    row.setLotesDisponibles(FXCollections.observableArrayList(lotes));
+                }
+                editDetalleItems.add(row);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
         modalEditar.setVisible(true);
     }
 
     @FXML
     protected void onCloseEditar() {
         modalEditar.setVisible(false);
+        editDetalleItems.clear();
+        originalDetalles.clear();
         editingAtencion = null;
     }
 
@@ -320,12 +426,41 @@ public class AtencionController {
         }
         editingAtencion.setNumeroReceta(receta.trim());
         editingAtencion.setMedico(txtEditMedico.getText() != null ? txtEditMedico.getText().trim() : "");
+
+        // Build new details list from edit table
+        List<AtencionDetalle> nuevas = new ArrayList<>();
+        for (EditableDetalleRow row : editDetalleItems) {
+            if (row.getLoteId() == null || row.getLoteId().isBlank()) {
+                showAlert(Alert.AlertType.WARNING, "Validación",
+                    "Seleccione un lote para: " + row.getProductoNombre());
+                return;
+            }
+            if (row.getCantidadEntregada() <= 0) {
+                showAlert(Alert.AlertType.WARNING, "Validación",
+                    "Ingrese una cantidad válida para: " + row.getProductoNombre());
+                return;
+            }
+            AtencionDetalle det = new AtencionDetalle();
+            det.setId(row.getDetalleId());
+            det.setLoteId(row.getLoteId());
+            det.setCantidadEntregada(row.getCantidadEntregada());
+            det.setProductoId(row.getProductoId());
+            det.setProductoNombre(row.getProductoNombre());
+            nuevas.add(det);
+        }
+
         try {
-            atencionAdapter.editarAtencion(editingAtencion);
-            showAlert(Alert.AlertType.INFORMATION, "Éxito", "Atención actualizada correctamente.");
-            modalEditar.setVisible(false);
-            editingAtencion = null;
-            onBuscarAtenciones();
+            String result = atencionAdapter.editarAtencionCompleta(editingAtencion, originalDetalles, nuevas);
+            if ("OK".equals(result)) {
+                showAlert(Alert.AlertType.INFORMATION, "Éxito", "Atención actualizada correctamente.");
+                modalEditar.setVisible(false);
+                editDetalleItems.clear();
+                originalDetalles.clear();
+                editingAtencion = null;
+                onBuscarAtenciones();
+            } else {
+                showAlert(Alert.AlertType.ERROR, "Error", result);
+            }
         } catch (Exception e) {
             showAlert(Alert.AlertType.ERROR, "Error", "No se pudo actualizar: " + e.getMessage());
         }
@@ -571,5 +706,33 @@ public class AtencionController {
         alert.initOwner(rootPane.getScene().getWindow());
         alert.getDialogPane().getStylesheets().add(getClass().getResource("/com/utp/meditrackapp/styles/global.css").toExternalForm());
         alert.showAndWait();
+    }
+
+    // Inner class for editable detail rows in the edit modal
+    public static class EditableDetalleRow {
+        private final StringProperty productoNombre = new SimpleStringProperty();
+        private final StringProperty loteNumero = new SimpleStringProperty();
+        private final IntegerProperty cantidadEntregada = new SimpleIntegerProperty();
+        private final StringProperty loteId = new SimpleStringProperty();
+        private final StringProperty productoId = new SimpleStringProperty();
+        private final StringProperty detalleId = new SimpleStringProperty();
+        private ObservableList<Lote> lotesDisponibles = FXCollections.observableArrayList();
+
+        public StringProperty productoNombreProperty() { return productoNombre; }
+        public StringProperty loteNumeroProperty() { return loteNumero; }
+        public IntegerProperty cantidadEntregadaProperty() { return cantidadEntregada; }
+        public StringProperty loteIdProperty() { return loteId; }
+        public StringProperty productoIdProperty() { return productoId; }
+        public StringProperty detalleIdProperty() { return detalleId; }
+
+        public ObservableList<Lote> getLotesDisponibles() { return lotesDisponibles; }
+        public void setLotesDisponibles(ObservableList<Lote> lotes) { this.lotesDisponibles = lotes; }
+
+        public String getProductoNombre() { return productoNombre.get(); }
+        public String getLoteNumero() { return loteNumero.get(); }
+        public int getCantidadEntregada() { return cantidadEntregada.get(); }
+        public String getLoteId() { return loteId.get(); }
+        public String getProductoId() { return productoId.get(); }
+        public String getDetalleId() { return detalleId.get(); }
     }
 }

--- a/src/main/java/com/utp/meditrackapp/features/inventory/ui/InventoryController.java
+++ b/src/main/java/com/utp/meditrackapp/features/inventory/ui/InventoryController.java
@@ -13,7 +13,6 @@ import com.utp.meditrackapp.domain.entities.Usuario;
 import com.utp.meditrackapp.core.models.enums.MotivoMovimientoEnum;
 import com.utp.meditrackapp.core.models.enums.TipoMovimientoEnum;
 import com.utp.meditrackapp.infrastructure.adapters.InventoryAdapter;
-import javafx.application.Platform;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.concurrent.Task;
@@ -21,7 +20,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.*;
 import javafx.scene.control.cell.PropertyValueFactory;
 import javafx.scene.layout.HBox;
-import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import javafx.util.StringConverter;
 import org.kordamp.ikonli.javafx.FontIcon;
@@ -66,6 +64,7 @@ public class InventoryController {
 
     // Quick Registration
     @FXML private ComboBox<TipoMovimiento> cmbQuickType;
+    @FXML private ComboBox<Producto> cmbQuickProduct;
     @FXML private ComboBox<Lote> cmbQuickBatch;
     @FXML private ComboBox<MotivoMovimiento> cmbQuickMotivo;
     @FXML private TextField txtQuickQty, txtQuickObs;
@@ -74,7 +73,7 @@ public class InventoryController {
     @FXML private ComboBox<Integer> cmbExpirationThreshold;
 
     // Modal fields
-    @FXML private StackPane modalMovement;
+    @FXML private VBox modalMovement;
     @FXML private VBox vboxEntradaDetails;
     @FXML private ComboBox<Producto> cmbModalProduct;
     @FXML private ComboBox<TipoMovimiento> cmbModalType;
@@ -84,6 +83,19 @@ public class InventoryController {
     @FXML private TextField txtNewLote, txtModalQty;
     @FXML private TextArea txtModalObs;
     @FXML private DatePicker dpNewVenc, dpNewFab;
+    @FXML private Label lblLoteError;
+
+    // Modal summary
+    @FXML private Label lblModalTitle, lblModalSubtitle;
+    @FXML private VBox vboxModalSummary;
+    @FXML private Label lblSummaryTipo, lblSummaryProducto, lblSummaryLote, lblSummaryCantidad;
+    @FXML private Button btnModalConfirm;
+
+    // Wizard
+    @FXML private VBox wizardStep1, wizardStep2, wizardStep3, wizardStep4;
+    @FXML private Button btnCancel, btnBack, btnNext, btnConfirm;
+    @FXML private Label lblStep1, lblStep2, lblStep3, lblStep4;
+    @FXML private Label lblStep3Title;
 
     // Pagination
     @FXML private Pagination paginationMovements;
@@ -91,12 +103,15 @@ public class InventoryController {
     private static final int ROWS_PER_PAGE = 10;
     private ObservableList<Movimiento> allMovements = FXCollections.observableArrayList();
     private ObservableList<Lote> allBatches = FXCollections.observableArrayList();
+    private boolean modalSummaryMode = false;
+    private int wizardStep = 1;
 
     @FXML
     public void initialize() {
         setupTables();
         loadDataInBackground();
         applyRolePermissions();
+        txtNewLote.textProperty().addListener((obs, oldVal, newVal) -> hideLoteError());
     }
 
     private void loadDataInBackground() {
@@ -184,19 +199,30 @@ public class InventoryController {
             @Override public String toString(MotivoMovimiento m) { return m != null ? m.getNombre() : ""; }
             @Override public MotivoMovimiento fromString(String s) { return null; }
         });
-        
+
         cmbModalProduct.setConverter(new StringConverter<>() {
             @Override public String toString(Producto p) { return p != null ? p.getNombre() : ""; }
             @Override public Producto fromString(String s) { return null; }
         });
+        cmbModalMotivo.setItems(FXCollections.observableArrayList(motivos));
         cmbModalMotivo.setConverter(new StringConverter<>() {
             @Override public String toString(MotivoMovimiento m) { return m != null ? m.getNombre() : ""; }
             @Override public MotivoMovimiento fromString(String s) { return null; }
         });
 
-        cmbQuickBatch.setItems(FXCollections.observableArrayList(lotes));
+        cmbQuickProduct.setItems(FXCollections.observableArrayList(productos));
+        cmbQuickProduct.setConverter(new StringConverter<>() {
+            @Override public String toString(Producto p) { return p != null ? p.getNombre() : ""; }
+            @Override public Producto fromString(String s) { return null; }
+        });
+        cmbQuickProduct.setOnAction(e -> onQuickProductChanged());
         cmbQuickBatch.setConverter(new StringConverter<>() {
-            @Override public String toString(Lote l) { return l != null ? l.getProductoNombre() + " [" + l.getNumeroLote() + "]" : ""; }
+            @Override public String toString(Lote l) {
+                if (l == null) return "";
+                java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy");
+                String vence = l.getFechaVencimiento() != null ? l.getFechaVencimiento().format(fmt) : "N/D";
+                return l.getNumeroLote() + " — Vence: " + vence + " — Stock: " + l.getCantidad();
+            }
             @Override public Lote fromString(String s) { return null; }
         });
 
@@ -585,55 +611,228 @@ public class InventoryController {
     }
 
     private void refreshQuickBatchCombo() {
+        Producto selectedProduct = cmbQuickProduct.getValue();
+        if (selectedProduct == null) {
+            cmbQuickBatch.getItems().clear();
+            cmbQuickBatch.setPromptText("Seleccione producto primero...");
+            return;
+        }
         try {
             Usuario user = sessionManager.getCurrentUser();
             if (user != null) {
-                List<Lote> batches = inventoryAdapter.listarLotesConProducto(user.getSedeId());
-                cmbQuickBatch.setItems(FXCollections.observableArrayList(batches));
+                List<Lote> allLots = inventoryAdapter.listarLotesConProducto(user.getSedeId());
+                List<Lote> productLots = allLots.stream()
+                    .filter(l -> selectedProduct.getId().equals(l.getProductoId()) && l.getCantidad() > 0)
+                    .collect(Collectors.toList());
+                cmbQuickBatch.setItems(FXCollections.observableArrayList(productLots));
+                if (!productLots.isEmpty()) {
+                    cmbQuickBatch.getSelectionModel().selectFirst();
+                }
             }
         } catch (Exception e) { e.printStackTrace(); }
     }
 
-    @FXML protected void onOpenMovementModal() { modalMovement.setVisible(true); }
-    @FXML protected void onCloseModal() { modalMovement.setVisible(false); }
+    private void onQuickProductChanged() {
+        refreshQuickBatchCombo();
+    }
+
+    @FXML protected void onOpenMovementModal() {
+        wizardStep = 1;
+        showWizardStep(1);
+        modalMovement.setVisible(true);
+        modalMovement.setManaged(true);
+    }
+    @FXML protected void onCloseModal() {
+        modalMovement.setVisible(false);
+        modalMovement.setManaged(false);
+        clearModalFields();
+    }
 
     @FXML
-    protected void onModalProductChanged() {
-        TipoMovimiento selectedType = cmbModalType.getValue();
-        if (selectedType != null && selectedType.getNombre().toLowerCase().contains("salida")) {
-            loadBatchesForProduct(cmbModalProduct.getValue());
+    protected void onWizardNext() {
+        if (wizardStep == 1) {
+            if (cmbModalType.getValue() == null || cmbModalMotivo.getValue() == null) {
+                showAlert(Alert.AlertType.WARNING, "Campos Incompletos", "Seleccione tipo y motivo.");
+                return;
+            }
+            wizardStep = 2;
+            showWizardStep(2);
+        } else if (wizardStep == 2) {
+            if (cmbModalProduct.getValue() == null) {
+                showAlert(Alert.AlertType.WARNING, "Campo Requerido", "Seleccione un producto.");
+                return;
+            }
+            TipoMovimiento tipo = cmbModalType.getValue();
+            boolean isEntrada = tipo.getNombre().toLowerCase().contains("entrada");
+            vboxEntradaDetails.setVisible(isEntrada);
+            vboxEntradaDetails.setManaged(isEntrada);
+            cmbModalBatchContainer.setVisible(!isEntrada);
+            cmbModalBatchContainer.setManaged(!isEntrada);
+            if (!isEntrada) loadBatchesForProduct(cmbModalProduct.getValue());
+            lblStep3Title.setText(isEntrada ? "Ingrese los datos del nuevo lote" : "Seleccione el lote a dispensar");
+            wizardStep = 3;
+            showWizardStep(3);
+        } else if (wizardStep == 3) {
+            if (!validateStep3()) return;
+            buildSummary();
+            wizardStep = 4;
+            showWizardStep(4);
         }
     }
 
     @FXML
-    protected void onModalTypeChanged() {
-        TipoMovimiento selectedType = cmbModalType.getValue();
-        if (selectedType == null) return;
+    protected void onWizardBack() {
+        if (wizardStep > 1) {
+            wizardStep--;
+            showWizardStep(wizardStep);
+        }
+    }
 
-        boolean isEntrada = selectedType.getNombre().toLowerCase().contains("entrada");
-        vboxEntradaDetails.setVisible(isEntrada);
-        vboxEntradaDetails.setManaged(isEntrada);
-        cmbModalBatchContainer.setVisible(!isEntrada);
-        cmbModalBatchContainer.setManaged(!isEntrada);
-        
+    private boolean validateStep3() {
+        String qtyStr = txtModalQty.getText();
+        if (qtyStr == null || qtyStr.isBlank()) {
+            showAlert(Alert.AlertType.WARNING, "Validación", "Ingrese la cantidad.");
+            return false;
+        }
+        int cantidad;
         try {
-            List<MotivoMovimiento> motivos = inventoryAdapter.listarMotivosMovimiento();
-            cmbModalMotivo.setItems(FXCollections.observableArrayList(motivos));
-        } catch (Exception e) { e.printStackTrace(); }
-        
-        if (!isEntrada) loadBatchesForProduct(cmbModalProduct.getValue());
+            cantidad = Integer.parseInt(qtyStr);
+            if (cantidad <= 0) throw new NumberFormatException();
+        } catch (NumberFormatException e) {
+            showAlert(Alert.AlertType.WARNING, "Validación", "La cantidad debe ser un número entero mayor a cero.");
+            return false;
+        }
+
+        TipoMovimiento tipo = cmbModalType.getValue();
+        boolean isEntrada = tipo.getNombre().toLowerCase().contains("entrada");
+        if (isEntrada) {
+            if (txtNewLote.getText() == null || txtNewLote.getText().isBlank()) {
+                showAlert(Alert.AlertType.WARNING, "Validación", "El N° de Lote es requerido para entradas.");
+                return false;
+            }
+            if (dpNewVenc.getValue() == null) {
+                showAlert(Alert.AlertType.WARNING, "Validación", "La Fecha de Vencimiento es requerida para entradas.");
+                return false;
+            }
+            Producto producto = cmbModalProduct.getValue();
+            Usuario user = sessionManager.getCurrentUser();
+            String numLote = txtNewLote.getText().trim();
+            if (inventoryAdapter.existeLote(numLote, producto.getId(), user.getSedeId())) {
+                lblLoteError.setText("Ya existe un lote \"" + numLote + "\" para este producto en esta sede.");
+                lblLoteError.setVisible(true);
+                lblLoteError.setManaged(true);
+                return false;
+            }
+            hideLoteError();
+        } else {
+            Lote lote = cmbModalBatch.getValue();
+            if (lote == null) {
+                showAlert(Alert.AlertType.WARNING, "Validación", "Seleccione un lote para salidas.");
+                return false;
+            }
+            if (lote.getCantidad() < cantidad) {
+                showAlert(Alert.AlertType.WARNING, "Stock insuficiente",
+                    "El lote " + lote.getNumeroLote() + " solo tiene " + lote.getCantidad() + " unidades.");
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private void buildSummary() {
+        TipoMovimiento tipo = cmbModalType.getValue();
+        MotivoMovimiento motivo = cmbModalMotivo.getValue();
+        Producto producto = cmbModalProduct.getValue();
+        int cantidad = Integer.parseInt(txtModalQty.getText());
+
+        lblSummaryTipo.setText("Tipo: " + tipo.getNombre().toUpperCase() + "  |  Motivo: " + motivo.getNombre());
+        lblSummaryProducto.setText("Producto: " + producto.getNombre());
+
+        boolean isEntrada = tipo.getNombre().toLowerCase().contains("entrada");
+        if (isEntrada) {
+            lblSummaryLote.setText("Lote: " + txtNewLote.getText() + "  |  Vence: " + dpNewVenc.getValue());
+        } else {
+            Lote lote = cmbModalBatch.getValue();
+            java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy");
+            String vence = lote.getFechaVencimiento() != null ? lote.getFechaVencimiento().format(fmt) : "N/D";
+            lblSummaryLote.setText("Lote: " + lote.getNumeroLote() + "  |  Vence: " + vence + "  |  Stock: " + lote.getCantidad());
+        }
+        String obs = txtModalObs.getText();
+        lblSummaryCantidad.setText("Cantidad: " + cantidad + (obs != null && !obs.isBlank() ? "  |  Obs: " + obs : ""));
+    }
+
+    private void showWizardStep(int step) {
+        wizardStep1.setVisible(step == 1);
+        wizardStep1.setManaged(step == 1);
+        wizardStep2.setVisible(step == 2);
+        wizardStep2.setManaged(step == 2);
+        wizardStep3.setVisible(step == 3);
+        wizardStep3.setManaged(step == 3);
+        wizardStep4.setVisible(step == 4);
+        wizardStep4.setManaged(step == 4);
+
+        btnCancel.setVisible(step < 4);
+        btnCancel.setManaged(step < 4);
+        btnBack.setVisible(step > 1);
+        btnBack.setManaged(step > 1);
+        btnNext.setVisible(step < 4);
+        btnNext.setManaged(step < 4);
+        btnConfirm.setVisible(step == 4);
+        btnConfirm.setManaged(step == 4);
+
+        String[] stepLabels = {"1. Tipo", "2. Producto", "3. Lote y Cant.", "4. Confirmar"};
+        Label[] stepLabelsUI = {lblStep1, lblStep2, lblStep3, lblStep4};
+        for (int i = 0; i < 4; i++) {
+            if (i + 1 == step) {
+                stepLabelsUI[i].setStyle("-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-accent-fg; -fx-text-fill: white; -fx-font-size: 11px; -fx-font-weight: bold;");
+            } else if (i + 1 < step) {
+                stepLabelsUI[i].setStyle("-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-success-fg; -fx-text-fill: white; -fx-font-size: 11px;");
+            } else {
+                stepLabelsUI[i].setStyle("-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-bg-subtle; -fx-text-fill: -color-fg-muted; -fx-font-size: 11px;");
+            }
+        }
+
+        String[] subtitles = {
+            "Paso 1 de 4 — Tipo y Motivo",
+            "Paso 2 de 4 — Seleccionar Producto",
+            "Paso 3 de 4 — Lote y Cantidad",
+            "Paso 4 de 4 — Confirmar Operación"
+        };
+        lblModalSubtitle.setText(subtitles[step - 1]);
+    }
+
+    @FXML
+    protected void onModalTypeChanged() {
     }
 
     private void loadBatchesForProduct(Producto p) {
-        if (p == null) return;
+        if (p == null) {
+            cmbModalBatch.getItems().clear();
+            cmbModalBatch.setPromptText("Seleccione producto primero...");
+            return;
+        }
         try {
             Usuario user = sessionManager.getCurrentUser();
             if (user == null) return;
             String sedeId = user.getSedeId();
-            List<Lote> lotes = inventoryAdapter.listarLotesFefo(sedeId, p.getId());
-            cmbModalBatch.setItems(FXCollections.observableArrayList(lotes));
+            List<Lote> allLots = inventoryAdapter.listarLotesConProducto(sedeId);
+            List<Lote> productLots = allLots.stream()
+                .filter(l -> p.getId().equals(l.getProductoId()) && l.getCantidad() > 0)
+                .sorted((a, b) -> {
+                    if (a.getFechaVencimiento() == null) return 1;
+                    if (b.getFechaVencimiento() == null) return -1;
+                    return a.getFechaVencimiento().compareTo(b.getFechaVencimiento());
+                })
+                .collect(Collectors.toList());
+
+            cmbModalBatch.setItems(FXCollections.observableArrayList(productLots));
             cmbModalBatch.setConverter(new StringConverter<>() {
-                @Override public String toString(Lote l) { return l != null ? l.getNumeroLote() : ""; }
+                @Override public String toString(Lote l) {
+                    if (l == null) return "";
+                    java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy");
+                    String vence = l.getFechaVencimiento() != null ? l.getFechaVencimiento().format(fmt) : "N/D";
+                    return l.getNumeroLote() + " — Vence: " + vence + " — Stock: " + l.getCantidad();
+                }
                 @Override public Lote fromString(String s) { return null; }
             });
             cmbModalBatch.setCellFactory(cb -> new javafx.scene.control.ListCell<>() {
@@ -641,10 +840,11 @@ public class InventoryController {
                 protected void updateItem(Lote item, boolean empty) {
                     super.updateItem(item, empty);
                     if (empty || item == null) {
-                        setText(null);
-                        setGraphic(null);
+                        setText(null); setGraphic(null); setStyle("");
                     } else {
-                        setText(item.getNumeroLote() + " (vence: " + item.getFechaVencimiento() + ")");
+                        java.time.format.DateTimeFormatter fmt = java.time.format.DateTimeFormatter.ofPattern("dd/MM/yyyy");
+                        String vence = item.getFechaVencimiento() != null ? item.getFechaVencimiento().format(fmt) : "N/D";
+                        setText(item.getNumeroLote() + " — Vence: " + vence + " — Stock: " + item.getCantidad());
                         if (getIndex() == 0) {
                             setStyle("-fx-font-weight: bold; -fx-text-fill: #2ea043;");
                         } else {
@@ -653,34 +853,22 @@ public class InventoryController {
                     }
                 }
             });
+
+            if (!productLots.isEmpty()) {
+                cmbModalBatch.getSelectionModel().selectFirst();
+            }
         } catch (Exception e) { e.printStackTrace(); }
     }
 
     @FXML
     protected void onSaveMovement() {
         try {
-            // Validar que la sede no esté bloqueada
             SedeAccessValidator.validarSedeActiva();
-            
+
             Producto producto = cmbModalProduct.getValue();
             TipoMovimiento selectedType = cmbModalType.getValue();
             MotivoMovimiento motivo = cmbModalMotivo.getValue();
-            String qtyStr = txtModalQty.getText();
-
-            if (producto == null || selectedType == null || motivo == null || qtyStr.isEmpty()) {
-                showAlert(Alert.AlertType.WARNING, "Campos Incompletos", "Por favor complete todos los campos obligatorios.");
-                return;
-            }
-
-            int cantidad;
-            try {
-                cantidad = Integer.parseInt(qtyStr);
-                if (cantidad <= 0) throw new NumberFormatException();
-            } catch (NumberFormatException e) {
-                showAlert(Alert.AlertType.WARNING, "Validación", "La cantidad debe ser un número entero mayor a cero.");
-                return;
-            }
-
+            int cantidad = Integer.parseInt(txtModalQty.getText());
             Usuario user = sessionManager.getCurrentUser();
             String obs = txtModalObs.getText();
             boolean isEntrada = selectedType.getNombre().toLowerCase().contains("entrada");
@@ -693,19 +881,9 @@ public class InventoryController {
                 nuevoLote.setFechaFabricacion(dpNewFab.getValue());
                 nuevoLote.setFechaVencimiento(dpNewVenc.getValue());
                 nuevoLote.setCantidad(cantidad);
-                
-                if (nuevoLote.getNumeroLote() == null || nuevoLote.getNumeroLote().isBlank() || nuevoLote.getFechaVencimiento() == null) {
-                    showAlert(Alert.AlertType.WARNING, "Datos de Lote", "Debe ingresar el N° de Lote y la Fecha de Vencimiento.");
-                    return;
-                }
-
                 inventoryAdapter.registrarMovimiento(nuevoLote, user.getId(), selectedType.getId(), motivo.getId(), cantidad, obs);
             } else {
                 Lote loteExistente = cmbModalBatch.getValue();
-                if (loteExistente == null) {
-                    showAlert(Alert.AlertType.WARNING, "Lote no seleccionado", "Debe seleccionar un lote para realizar una salida.");
-                    return;
-                }
                 inventoryAdapter.registrarMovimiento(loteExistente, user.getId(), selectedType.getId(), motivo.getId(), cantidad, obs);
             }
 
@@ -714,7 +892,6 @@ public class InventoryController {
             refreshMovements();
             refreshBatches();
             refreshQuickBatchCombo();
-            clearModalFields();
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -723,6 +900,8 @@ public class InventoryController {
     }
 
     private void clearModalFields() {
+        modalSummaryMode = false;
+        wizardStep = 1;
         txtModalQty.clear();
         txtModalObs.clear();
         txtNewLote.clear();
@@ -732,6 +911,19 @@ public class InventoryController {
         cmbModalType.getSelectionModel().clearSelection();
         cmbModalMotivo.getSelectionModel().clearSelection();
         cmbModalBatch.getSelectionModel().clearSelection();
+        cmbModalBatch.getItems().clear();
+        vboxEntradaDetails.setVisible(false);
+        vboxEntradaDetails.setManaged(false);
+        cmbModalBatchContainer.setVisible(false);
+        cmbModalBatchContainer.setManaged(false);
+        hideLoteError();
+    }
+
+    private void hideLoteError() {
+        if (lblLoteError != null) {
+            lblLoteError.setVisible(false);
+            lblLoteError.setManaged(false);
+        }
     }
 
     @FXML

--- a/src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/adapters/AtencionAdapter.java
@@ -10,6 +10,8 @@ import com.utp.meditrackapp.domain.entities.Producto;
 import com.utp.meditrackapp.domain.ports.out.AtencionRepository;
 import com.utp.meditrackapp.domain.ports.out.DispensacionRepository;
 import com.utp.meditrackapp.domain.services.dispensacion.DispensarMedicamentoUseCase;
+import com.utp.meditrackapp.domain.services.dispensacion.EditarAtencionUseCase;
+import com.utp.meditrackapp.domain.services.dispensacion.EliminarAtencionUseCase;
 import com.utp.meditrackapp.domain.services.paciente.GestionarPacienteUseCase;
 import com.utp.meditrackapp.infrastructure.persistence.jdbc.JdbcAtencionRepository;
 import com.utp.meditrackapp.infrastructure.persistence.jdbc.JdbcDispensacionRepository;
@@ -28,6 +30,8 @@ import java.util.stream.Collectors;
  */
 public class AtencionAdapter {
     private final DispensarMedicamentoUseCase dispensarUseCase;
+    private final EditarAtencionUseCase editarAtencionUseCase;
+    private final EliminarAtencionUseCase eliminarAtencionUseCase;
     private final GestionarPacienteUseCase pacienteUseCase;
     private final JdbcAtencionRepository atencionRepository;
     private final JdbcDispensacionRepository dispensacionRepository;
@@ -38,6 +42,18 @@ public class AtencionAdapter {
         this.atencionRepository = new JdbcAtencionRepository();
         JdbcPacienteRepository pacienteRepo = new JdbcPacienteRepository();
         this.dispensarUseCase = new DispensarMedicamentoUseCase(
+            atencionRepository,
+            new JdbcLoteRepository(),
+            new JdbcMovimientoRepository(),
+            new TransactionManager()
+        );
+        this.editarAtencionUseCase = new EditarAtencionUseCase(
+            atencionRepository,
+            new JdbcLoteRepository(),
+            new JdbcMovimientoRepository(),
+            new TransactionManager()
+        );
+        this.eliminarAtencionUseCase = new EliminarAtencionUseCase(
             atencionRepository,
             new JdbcLoteRepository(),
             new JdbcMovimientoRepository(),
@@ -115,9 +131,17 @@ public class AtencionAdapter {
         return "OK";
     }
 
+    public String editarAtencionCompleta(Atencion atencion, List<AtencionDetalle> originales, List<AtencionDetalle> nuevas) {
+        return editarAtencionUseCase.editarAtencion(atencion, originales, nuevas);
+    }
+
+    public void editarDetalle(String detalleId, String nuevoLoteId, int nuevaCantidad) {
+        atencionRepository.updateDetalle(detalleId, nuevoLoteId, nuevaCantidad);
+    }
+
     public String eliminarAtencion(String atencionId) {
-        atencionRepository.deleteAtencion(atencionId);
-        return "OK";
+        com.utp.meditrackapp.domain.entities.Usuario user = com.utp.meditrackapp.core.config.SessionManager.getInstance().getCurrentUser();
+        return eliminarAtencionUseCase.eliminar(atencionId, user.getSedeId(), user.getId());
     }
 
     private DispensacionReportDTO toDispensacionDTO(Object raw) {

--- a/src/main/java/com/utp/meditrackapp/infrastructure/adapters/InventoryAdapter.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/adapters/InventoryAdapter.java
@@ -85,6 +85,10 @@ public class InventoryAdapter {
         return loteRepository.findFefo(sedeId, productoId);
     }
 
+    public boolean existeLote(String numeroLote, String productoId, String sedeId) {
+        return loteRepository.existsByNumeroLoteProductoSede(numeroLote, productoId, sedeId);
+    }
+
     public List<StockCriticoDTO> obtenerStockCritico(String sedeId) {
         return calcularStockUseCase.calcularStockCritico(sedeId, 10);
     }

--- a/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcAtencionRepository.java
@@ -260,7 +260,7 @@ public class JdbcAtencionRepository implements AtencionRepository {
     @Override
     public List<AtencionDetalle> findDetallesByAtencionId(String atencionId) {
         List<AtencionDetalle> lista = new ArrayList<>();
-        String sql = "SELECT ad.*, l.numero_lote, l.fecha_vencimiento, p.nombre as producto_nombre " +
+        String sql = "SELECT ad.*, l.numero_lote, l.fecha_vencimiento, l.producto_id, p.nombre as producto_nombre " +
             "FROM atencion_detalles ad " +
             "JOIN lotes l ON ad.lote_id = l.id " +
             "JOIN productos p ON l.producto_id = p.id " +
@@ -276,6 +276,7 @@ public class JdbcAtencionRepository implements AtencionRepository {
                     d.setLoteId(rs.getString("lote_id"));
                     d.setCantidadEntregada(rs.getInt("cantidad_entregada"));
                     d.setLoteNumero(rs.getString("numero_lote"));
+                    d.setProductoId(rs.getString("producto_id"));
                     d.setProductoNombre(rs.getString("producto_nombre"));
                     Timestamp vence = rs.getTimestamp("fecha_vencimiento");
                     if (vence != null) {
@@ -305,6 +306,20 @@ public class JdbcAtencionRepository implements AtencionRepository {
     }
 
     @Override
+    public void updateDetalle(String detalleId, String nuevoLoteId, int nuevaCantidad) {
+        String sql = "UPDATE atencion_detalles SET lote_id = ?, cantidad_entregada = ? WHERE id = ?";
+        try (Connection conn = dbConfig.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, nuevoLoteId);
+            ps.setInt(2, nuevaCantidad);
+            ps.setString(3, detalleId);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error al actualizar detalle: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
     public void deleteAtencion(String atencionId) {
         String sqlDetalles = "DELETE FROM atencion_detalles WHERE atencion_id = ?";
         String sqlAtencion = "DELETE FROM atenciones WHERE id = ?";
@@ -323,6 +338,31 @@ public class JdbcAtencionRepository implements AtencionRepository {
             }
         } catch (SQLException e) {
             throw new RuntimeException("Error al eliminar atención: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteDetallesByAtencionId(java.sql.Connection conn, String atencionId) {
+        String sql = "DELETE FROM atencion_detalles WHERE atencion_id = ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, atencionId);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error al eliminar detalles: " + e.getMessage(), e);
+        }
+    }
+
+    @Override
+    public void deleteMovimientosByAtencionId(java.sql.Connection conn, String atencionId) {
+        String sql = "DELETE FROM movimientos WHERE lote_id IN " +
+            "(SELECT lote_id FROM atencion_detalles WHERE atencion_id = ?) " +
+            "AND observacion LIKE ?";
+        try (PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, atencionId);
+            ps.setString(2, "%Receta:%");
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException("Error al eliminar movimientos: " + e.getMessage(), e);
         }
     }
 }

--- a/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcLoteRepository.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcLoteRepository.java
@@ -209,6 +209,25 @@ public class JdbcLoteRepository implements LoteRepository {
     }
 
     @Override
+    public boolean existsByNumeroLoteProductoSede(String numeroLote, String productoId, String sedeId) {
+        String sql = "SELECT COUNT(*) FROM lotes WHERE numero_lote = ? AND producto_id = ? AND sede_id = ?";
+        try (Connection conn = dbConfig.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, numeroLote);
+            ps.setString(2, productoId);
+            ps.setString(3, sedeId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1) > 0;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    @Override
     public Lote save(Lote lote) {
         try (Connection conn = dbConfig.getConnection()) {
             return save(conn, lote);

--- a/src/main/resources/com/utp/meditrackapp/atencion-view.fxml
+++ b/src/main/resources/com/utp/meditrackapp/atencion-view.fxml
@@ -178,7 +178,7 @@
 
     <!-- Modal: Editar Atención -->
     <StackPane fx:id="modalEditar" visible="false" styleClass="modal-overlay">
-        <VBox maxWidth="450" maxHeight="-Infinity" styleClass="modal-content" spacing="20">
+        <VBox maxWidth="750" maxHeight="-Infinity" styleClass="modal-content" spacing="20">
             <VBox styleClass="modal-header">
                 <Label text="Editar Atención" styleClass="title-4" />
                 <Label fx:id="lblEditarSub" text="" styleClass="text-muted" />
@@ -193,6 +193,23 @@
                     <TextField fx:id="txtEditMedico" maxWidth="Infinity" />
                 </VBox>
             </VBox>
+
+            <!-- Detalle de medicamentos editable -->
+            <VBox spacing="6">
+                <Label text="DETALLE DE MEDICAMENTOS" styleClass="text-caption, text-bold, text-muted" />
+                <TableView fx:id="tableEditDetalle" prefHeight="180" maxWidth="Infinity">
+                    <columns>
+                        <TableColumn fx:id="colEditProducto" text="Producto" prefWidth="220" />
+                        <TableColumn fx:id="colEditLote" text="Lote" prefWidth="250" />
+                        <TableColumn fx:id="colEditCantidad" text="Cantidad" prefWidth="100" />
+                    </columns>
+                    <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
+                    <placeholder>
+                        <Label text="Esta atención no tiene medicamentos registrados." styleClass="text-muted" />
+                    </placeholder>
+                </TableView>
+            </VBox>
+
             <HBox spacing="15" alignment="CENTER_RIGHT" styleClass="modal-footer">
                 <Button text="Cancelar" onAction="#onCloseEditar" styleClass="button, flat" />
                 <Button text="Guardar" onAction="#onSaveEditar" styleClass="button, accent" />

--- a/src/main/resources/com/utp/meditrackapp/inventory-view.fxml
+++ b/src/main/resources/com/utp/meditrackapp/inventory-view.fxml
@@ -88,24 +88,32 @@
                             
                             <Tab text="Monitor de Lotes">
                                 <VBox spacing="15" style="-fx-padding: 20 0 0 0;">
-                                    <!-- Registro Rápido: full width arriba -->
+                                    <!-- Registro Rápido -->
                                     <VBox styleClass="card, elevated" spacing="12" style="-fx-padding: 15;">
                                         <HBox alignment="CENTER_LEFT" spacing="10">
                                             <FontIcon iconLiteral="fas-bolt" iconSize="16" styleClass="icon-accent" />
                                             <Label text="REGISTRO RÁPIDO" styleClass="text-caption, text-bold, text-muted" />
                                         </HBox>
+                                        <!-- Fila 1: Tipo, Producto, Motivo -->
                                         <HBox spacing="15" alignment="BOTTOM_LEFT">
-                                            <VBox spacing="4" HBox.hgrow="ALWAYS">
+                                            <VBox spacing="4" maxWidth="180">
                                                 <Label text="TIPO" styleClass="text-caption, text-muted" />
                                                 <ComboBox fx:id="cmbQuickType" maxWidth="Infinity" promptText="Seleccionar" />
                                             </VBox>
                                             <VBox spacing="4" HBox.hgrow="ALWAYS">
-                                                <Label text="LOTE" styleClass="text-caption, text-muted" />
-                                                <ComboBox fx:id="cmbQuickBatch" maxWidth="Infinity" promptText="Seleccionar lote" />
+                                                <Label text="PRODUCTO" styleClass="text-caption, text-muted" />
+                                                <ComboBox fx:id="cmbQuickProduct" maxWidth="Infinity" promptText="Seleccionar producto..." />
                                             </VBox>
-                                            <VBox spacing="4" HBox.hgrow="ALWAYS">
+                                            <VBox spacing="4" maxWidth="200">
                                                 <Label text="MOTIVO" styleClass="text-caption, text-muted" />
                                                 <ComboBox fx:id="cmbQuickMotivo" maxWidth="Infinity" promptText="Seleccionar motivo" />
+                                            </VBox>
+                                        </HBox>
+                                        <!-- Fila 2: Lote, Cantidad, Observaciones, Registrar -->
+                                        <HBox spacing="15" alignment="BOTTOM_LEFT">
+                                            <VBox spacing="4" HBox.hgrow="ALWAYS">
+                                                <Label text="LOTE" styleClass="text-caption, text-muted" />
+                                                <ComboBox fx:id="cmbQuickBatch" maxWidth="Infinity" promptText="Seleccione producto primero..." />
                                             </VBox>
                                             <VBox spacing="4" maxWidth="120">
                                                 <Label text="CANTIDAD" styleClass="text-caption, text-muted" />
@@ -116,7 +124,6 @@
                                                 <TextField fx:id="txtQuickObs" promptText="Notas breves" />
                                             </VBox>
                                             <Button text="Registrar" onAction="#onQuickUpdate" styleClass="button, accent">
-                                                <graphic><FontIcon iconLiteral="fas-sync-alt" iconColor="white" /></graphic>
                                                 <VBox.margin><Insets bottom="2" /></VBox.margin>
                                             </Button>
                                         </HBox>
@@ -168,71 +175,101 @@
         </center>
     </BorderPane>
 
-    <!-- Movement Modal -->
-    <StackPane fx:id="modalMovement" visible="false" styleClass="modal-overlay">
-        <VBox maxWidth="600" maxHeight="-Infinity" styleClass="modal-content" spacing="25">
+    <!-- Movement Modal - Wizard -->
+    <VBox fx:id="modalMovement" visible="false" managed="false" alignment="CENTER" style="-fx-background-color: rgba(0,0,0,0.45);">
+        <VBox maxWidth="650" styleClass="modal-content" spacing="15">
             <VBox styleClass="modal-header">
-                <Label text="Registrar Operación de Inventario" styleClass="title-4" />
-                <Label text="Ingrese los detalles de la entrada o salida a continuación." styleClass="text-muted" />
+                <Label fx:id="lblModalTitle" text="Registrar Operación de Inventario" styleClass="title-4" />
+                <Label fx:id="lblModalSubtitle" text="Paso 1 de 4 — Tipo y Motivo" styleClass="text-muted" />
             </VBox>
-            
-            <ScrollPane fitToWidth="true" VBox.vgrow="ALWAYS">
-                <VBox spacing="25">
-                    <VBox spacing="8">
-                        <Label text="PRODUCTO / MEDICAMENTO" styleClass="text-caption, text-bold, text-muted" />
-                        <ComboBox fx:id="cmbModalProduct" maxWidth="Infinity" promptText="Seleccionar de la lista" onAction="#onModalProductChanged" styleClass="large" />
+
+            <!-- Step indicator -->
+            <HBox spacing="8" alignment="CENTER_LEFT" style="-fx-padding: 0 0 5 0;">
+                <Label fx:id="lblStep1" text="1. Tipo" style="-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-accent-fg; -fx-text-fill: white; -fx-font-size: 11px; -fx-font-weight: bold;" />
+                <Label fx:id="lblStep2" text="2. Producto" style="-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-bg-subtle; -fx-text-fill: -color-fg-muted; -fx-font-size: 11px;" />
+                <Label fx:id="lblStep3" text="3. Lote y Cant." style="-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-bg-subtle; -fx-text-fill: -color-fg-muted; -fx-font-size: 11px;" />
+                <Label fx:id="lblStep4" text="4. Confirmar" style="-fx-padding: 3 10; -fx-background-radius: 12; -fx-background-color: -color-bg-subtle; -fx-text-fill: -color-fg-muted; -fx-font-size: 11px;" />
+            </HBox>
+
+            <!-- ===== PASO 1: Tipo + Motivo ===== -->
+            <VBox fx:id="wizardStep1" spacing="15">
+                <Label text="¿Qué tipo de operación va a registrar?" styleClass="text-muted" />
+                <VBox spacing="6">
+                    <Label text="TIPO DE MOVIMIENTO *" styleClass="text-caption, text-bold, text-muted" />
+                    <ComboBox fx:id="cmbModalType" maxWidth="Infinity" promptText="Seleccionar tipo..." />
+                </VBox>
+                <VBox spacing="6">
+                    <Label text="MOTIVO *" styleClass="text-caption, text-bold, text-muted" />
+                    <ComboBox fx:id="cmbModalMotivo" maxWidth="Infinity" promptText="Seleccionar motivo..." />
+                </VBox>
+            </VBox>
+
+            <!-- ===== PASO 2: Producto ===== -->
+            <VBox fx:id="wizardStep2" visible="false" managed="false" spacing="15">
+                <Label text="¿Qué producto o medicamento va a operar?" styleClass="text-muted" />
+                <VBox spacing="6">
+                    <Label text="PRODUCTO / MEDICAMENTO *" styleClass="text-caption, text-bold, text-muted" />
+                    <ComboBox fx:id="cmbModalProduct" maxWidth="Infinity" promptText="Seleccionar producto..." />
+                </VBox>
+            </VBox>
+
+            <!-- ===== PASO 3: Lote + Cantidad ===== -->
+            <VBox fx:id="wizardStep3" visible="false" managed="false" spacing="15">
+                <Label fx:id="lblStep3Title" text="Detalle del lote y cantidad" styleClass="text-muted" />
+
+                <!-- Si ENTRADA: datos del nuevo lote -->
+                <VBox fx:id="vboxEntradaDetails" visible="false" managed="false" spacing="12" style="-fx-padding: 15; -fx-background-color: -color-bg-subtle; -fx-background-radius: 10;">
+                    <Label text="DATOS DEL NUEVO LOTE" styleClass="text-caption, text-bold, text-muted" />
+                    <VBox spacing="6">
+                        <Label text="N° de Lote (Proveedor) *" styleClass="text-caption, text-muted" />
+                        <TextField fx:id="txtNewLote" promptText="Ej: LOT-2026-X  (asignado por el proveedor/fabricante)" maxWidth="Infinity" />
+                        <Label fx:id="lblLoteError" visible="false" managed="false"
+                               style="-fx-text-fill: -color-danger-fg; -fx-font-size: 11px;" />
                     </VBox>
-                    
-                    <HBox spacing="25">
-                        <VBox HBox.hgrow="ALWAYS" spacing="8">
-                            <Label text="TIPO DE MOVIMIENTO" styleClass="text-caption, text-bold, text-muted" />
-                            <ComboBox fx:id="cmbModalType" maxWidth="Infinity" promptText="Operación" onAction="#onModalTypeChanged" />
+                    <HBox spacing="20">
+                        <VBox spacing="6" HBox.hgrow="ALWAYS">
+                            <Label text="Fecha Fabricación (opcional)" styleClass="text-caption, text-muted" />
+                            <DatePicker fx:id="dpNewFab" maxWidth="Infinity" />
                         </VBox>
-                        <VBox HBox.hgrow="ALWAYS" spacing="8">
-                            <Label text="MOTIVO" styleClass="text-caption, text-bold, text-muted" />
-                            <ComboBox fx:id="cmbModalMotivo" maxWidth="Infinity" promptText="Razón del registro" />
-                        </VBox>
-                    </HBox>
-                    
-                    <VBox fx:id="vboxEntradaDetails" visible="false" managed="false" spacing="20" style="-fx-padding: 15; -fx-background-color: -color-bg-subtle; -fx-background-radius: 10;">
-                        <VBox spacing="8">
-                            <Label text="IDENTIFICACIÓN DE LOTE (PROVEEDOR)" styleClass="text-caption, text-bold, text-muted" />
-                            <TextField fx:id="txtNewLote" promptText="Ej: LOT-2026-X" />
-                        </VBox>
-                        <HBox spacing="20">
-                            <VBox HBox.hgrow="ALWAYS" spacing="8">
-                                <Label text="FECHA FABRICACIÓN" styleClass="text-caption, text-bold, text-muted" />
-                                <DatePicker fx:id="dpNewFab" maxWidth="Infinity" />
-                            </VBox>
-                            <VBox HBox.hgrow="ALWAYS" spacing="8">
-                                <Label text="FECHA VENCIMIENTO" styleClass="text-caption, text-bold, text-muted" />
-                                <DatePicker fx:id="dpNewVenc" maxWidth="Infinity" />
-                            </VBox>
-                        </HBox>
-                    </VBox>
-                    
-                    <VBox fx:id="cmbModalBatchContainer" visible="false" managed="false" spacing="8">
-                        <Label text="SELECCIONAR LOTE DISPONIBLE" styleClass="text-caption, text-bold, text-muted" />
-                        <ComboBox fx:id="cmbModalBatch" maxWidth="Infinity" promptText="Lotes activos en sede" />
-                    </VBox>
-                    
-                    <HBox spacing="25">
-                        <VBox prefWidth="180" spacing="8">
-                            <Label text="CANTIDAD" styleClass="text-caption, text-bold, text-muted" />
-                            <TextField fx:id="txtModalQty" promptText="0" styleClass="large" />
-                        </VBox>
-                        <VBox HBox.hgrow="ALWAYS" spacing="8">
-                            <Label text="OBSERVACIONES" styleClass="text-caption, text-bold, text-muted" />
-                            <TextArea fx:id="txtModalObs" prefHeight="90" wrapText="true" promptText="Notas adicionales del movimiento..." />
+                        <VBox spacing="6" HBox.hgrow="ALWAYS">
+                            <Label text="Fecha Vencimiento *" styleClass="text-caption, text-muted" />
+                            <DatePicker fx:id="dpNewVenc" maxWidth="Infinity" />
                         </VBox>
                     </HBox>
                 </VBox>
-            </ScrollPane>
-            
-            <HBox spacing="15" alignment="CENTER_RIGHT" styleClass="modal-footer">
-                <Button text="Cancelar" onAction="#onCloseModal" styleClass="button, flat" />
-                <Button text="Confirmar y Guardar" onAction="#onSaveMovement" styleClass="button, accent, large" />
+
+                <!-- Si SALIDA: seleccionar lote existente -->
+                <VBox fx:id="cmbModalBatchContainer" visible="false" managed="false" spacing="6">
+                    <Label text="LOTE DISPONIBLE (FEFO) *" styleClass="text-caption, text-bold, text-muted" />
+                    <ComboBox fx:id="cmbModalBatch" maxWidth="Infinity" promptText="Seleccionar producto primero..." />
+                </VBox>
+
+                <VBox spacing="6">
+                    <Label text="CANTIDAD *" styleClass="text-caption, text-bold, text-muted" />
+                    <TextField fx:id="txtModalQty" promptText="0" maxWidth="200" />
+                </VBox>
+                <VBox spacing="6">
+                    <Label text="OBSERVACIONES (opcional)" styleClass="text-caption, text-bold, text-muted" />
+                    <TextArea fx:id="txtModalObs" prefHeight="60" wrapText="true" promptText="Notas adicionales del movimiento..." maxWidth="Infinity" />
+                </VBox>
+            </VBox>
+
+            <!-- ===== PASO 4: Resumen ===== -->
+            <VBox fx:id="wizardStep4" visible="false" managed="false" spacing="12" style="-fx-padding: 15; -fx-background-color: -color-accent-subtle; -fx-background-radius: 8; -fx-border-color: -color-accent-fg; -fx-border-width: 1; -fx-border-radius: 8;">
+                <Label text="RESUMEN DE LA OPERACIÓN" styleClass="text-caption, text-bold" style="-fx-text-fill: -color-accent-fg;" />
+                <Label fx:id="lblSummaryTipo" text="" styleClass="text-caption" />
+                <Label fx:id="lblSummaryProducto" text="" styleClass="text-caption" />
+                <Label fx:id="lblSummaryLote" text="" styleClass="text-caption" />
+                <Label fx:id="lblSummaryCantidad" text="" styleClass="text-caption" />
+            </VBox>
+
+            <!-- Footer: navigation buttons -->
+            <HBox spacing="10" alignment="CENTER_RIGHT" styleClass="modal-footer">
+                <Button fx:id="btnCancel" text="Cancelar" onAction="#onCloseModal" styleClass="button, flat" />
+                <Button fx:id="btnBack" text="← Anterior" onAction="#onWizardBack" styleClass="button, flat" visible="false" managed="false" />
+                <Button fx:id="btnNext" text="Siguiente →" onAction="#onWizardNext" styleClass="button, accent" />
+                <Button fx:id="btnConfirm" text="Confirmar y Guardar" onAction="#onSaveMovement" styleClass="button, accent, large" visible="false" managed="false" />
             </HBox>
         </VBox>
-    </StackPane>
+    </VBox>
 </StackPane>


### PR DESCRIPTION
…s with stock adjustment

- Add lot duplicate validation in inventory modal (same product + same sede)
- Add inline error label for lot validation in inventory wizard
- Add editable detail table in atencion edit modal (Lote ComboBox + Cantidad TextField)
- Create EditarAtencionUseCase with stock reversal logic (reverse old → apply new)
- Create EliminarAtencionUseCase to restore stock on attention deletion
- Add deleteDetallesByAtencionId and deleteMovimientosByAtencionId to repository
- Add productoId to AtencionDetalle for lot loading per product
- Fix eliminarAtencion to properly restore stock and clean movement records

BREAKING CHANGE: eliminarAtencion now requires session context for stock restoration