### PR TITLE
feat(productos): add permanent delete with global inventory validation

### DIFF
--- a/src/main/java/com/utp/meditrackapp/domain/ports/out/LoteRepository.java
+++ b/src/main/java/com/utp/meditrackapp/domain/ports/out/LoteRepository.java
@@ -39,6 +39,11 @@ public interface LoteRepository {
     boolean existsByNumeroLoteProductoSede(String numeroLote, String productoId, String sedeId);
 
     /**
+     * Verifica si existe al menos un lote para el producto en cualquier sede.
+     */
+    boolean existsByProducto(String productoId);
+
+    /**
      * Versión sin Connection para operaciones simples que manejan su propia conexión.
      */
     Lote save(Lote lote);

--- a/src/main/java/com/utp/meditrackapp/domain/ports/out/ProductoRepository.java
+++ b/src/main/java/com/utp/meditrackapp/domain/ports/out/ProductoRepository.java
@@ -11,5 +11,6 @@ public interface ProductoRepository {
     Producto save(Producto producto);
     Producto update(Producto producto);
     void desactivar(String id);
+    void eliminar(String id);
     boolean existeCodigoDigemid(String codigoDigemid);
 }

--- a/src/main/java/com/utp/meditrackapp/domain/services/inventario/CalcularStockUseCase.java
+++ b/src/main/java/com/utp/meditrackapp/domain/services/inventario/CalcularStockUseCase.java
@@ -44,6 +44,13 @@ public class CalcularStockUseCase {
     }
 
     /**
+     * Verifica si un producto tiene lotes (inventario) en cualquier sede.
+     */
+    public boolean tieneLotes(String productoId) {
+        return loteRepository.existsByProducto(productoId);
+    }
+
+    /**
      * Calcula el ítems de stock crítico para una sede.
      * Combina stock bajo y lotes por vencer.
      *

--- a/src/main/java/com/utp/meditrackapp/domain/services/producto/GestionarProductoUseCase.java
+++ b/src/main/java/com/utp/meditrackapp/domain/services/producto/GestionarProductoUseCase.java
@@ -68,6 +68,18 @@ public class GestionarProductoUseCase {
         }
     }
 
+    public String eliminar(String id) {
+        Optional<Producto> opt = productoRepository.findById(id);
+        if (opt.isEmpty()) return "Producto no encontrado.";
+
+        try {
+            productoRepository.eliminar(id);
+            return "OK";
+        } catch (Exception e) {
+            return "Error al eliminar producto: " + e.getMessage();
+        }
+    }
+
     public List<Categoria> listarCategorias() {
         return categoriaRepository.findAll();
     }

--- a/src/main/java/com/utp/meditrackapp/features/products/ui/ProductoController.java
+++ b/src/main/java/com/utp/meditrackapp/features/products/ui/ProductoController.java
@@ -132,16 +132,21 @@ public class ProductoController {
 
         colAcciones.setCellFactory(column -> new TableCell<>() {
             private final Button editBtn = new Button();
-            private final Button deleteBtn = new Button();
+            private final Button deactivateBtn = new Button();
+            private final Button permanentDeleteBtn = new Button();
             private final boolean canWrite = sessionManager.tienePermiso("M2_SEDES");
             {
                 editBtn.setGraphic(new FontIcon("fas-edit"));
                 editBtn.getStyleClass().addAll("button", "flat", "accent", "sm");
                 editBtn.setOnAction(e -> openEditModal(getTableRow().getItem()));
 
-                deleteBtn.setGraphic(new FontIcon("fas-trash"));
-                deleteBtn.getStyleClass().addAll("button", "flat", "danger", "sm");
-                deleteBtn.setOnAction(e -> confirmDelete(getTableRow().getItem()));
+                deactivateBtn.setGraphic(new FontIcon("fas-toggle-off"));
+                deactivateBtn.getStyleClass().addAll("button", "flat", "warning", "sm");
+                deactivateBtn.setOnAction(e -> confirmDelete(getTableRow().getItem()));
+
+                permanentDeleteBtn.setGraphic(new FontIcon("fas-trash"));
+                permanentDeleteBtn.getStyleClass().addAll("button", "flat", "danger", "sm");
+                permanentDeleteBtn.setOnAction(e -> confirmPermanentDelete(getTableRow().getItem()));
             }
 
             @Override protected void updateItem(Void item, boolean empty) {
@@ -151,7 +156,8 @@ public class ProductoController {
                     if (!canWrite) {
                         setGraphic(null);
                     } else {
-                        HBox box = new HBox(10, editBtn, deleteBtn);
+                        HBox box = new HBox(8, editBtn, deactivateBtn, permanentDeleteBtn);
+                        box.getStyleClass().add("actions-cell");
                         box.setAlignment(Pos.CENTER);
                         setGraphic(box);
                     }
@@ -375,16 +381,51 @@ public class ProductoController {
         }
 
         TextInputDialog dialog = new TextInputDialog();
-        dialog.setTitle("Confirmar Eliminación");
+        dialog.setTitle("Confirmar Desactivación");
         dialog.setHeaderText("¿Está seguro de desactivar el producto \"" + p.getNombre() + "\"?");
-        dialog.setContentText("Esta acción no se puede deshacer. Escriba 'ELIMINAR' para confirmar:");
+        dialog.setContentText("El producto quedará inactivo. Escriba 'DESACTIVAR' para confirmar:");
         Optional<String> result = dialog.showAndWait();
-        if (result.isPresent() && "ELIMINAR".equals(result.get().trim().toUpperCase())) {
+        if (result.isPresent() && "DESACTIVAR".equals(result.get().trim().toUpperCase())) {
             try {
                 productoAdapter.desactivarProducto(p.getId());
                 loadData();
             } catch (Exception e) {
                 showAlert(Alert.AlertType.ERROR, "Error", "No se pudo desactivar el producto.");
+            }
+        }
+    }
+
+    private void confirmPermanentDelete(Producto p) {
+        if (p == null) return;
+        if (!sessionManager.tienePermiso("M2_SEDES")) {
+            showAlert(Alert.AlertType.WARNING, "Sin permisos", "No tiene permisos para eliminar productos.");
+            return;
+        }
+
+        // Verificar si el producto tiene inventario en CUALQUIER sede
+        try {
+            if (productoAdapter.productoTieneLotes(p.getId())) {
+                showAlert(Alert.AlertType.WARNING, "Inventario Activo",
+                    "El producto \"" + p.getNombre() + "\" tiene registros de inventario en una o más sedes. No se puede eliminar.");
+                return;
+            }
+        } catch (Exception e) {
+            showAlert(Alert.AlertType.ERROR, "Error", "No se pudo verificar el inventario del producto.");
+            return;
+        }
+
+        TextInputDialog dialog = new TextInputDialog();
+        dialog.setTitle("Confirmar Eliminación Permanente");
+        dialog.setHeaderText("¿Está seguro de ELIMINAR permanentemente el producto \"" + p.getNombre() + "\"?");
+        dialog.setContentText("Esta acción es IRREVERSIBLE. Escriba 'ELIMINAR' para confirmar:");
+        Optional<String> result = dialog.showAndWait();
+        if (result.isPresent() && "ELIMINAR".equals(result.get().trim().toUpperCase())) {
+            try {
+                productoAdapter.eliminarProducto(p.getId());
+                loadData();
+                showAlert(Alert.AlertType.INFORMATION, "Éxito", "Producto eliminado permanentemente.");
+            } catch (Exception e) {
+                showAlert(Alert.AlertType.ERROR, "Error", "No se pudo eliminar el producto.");
             }
         }
     }

--- a/src/main/java/com/utp/meditrackapp/infrastructure/adapters/ProductoAdapter.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/adapters/ProductoAdapter.java
@@ -49,12 +49,22 @@ public class ProductoAdapter {
         return r;
     }
 
+    public String eliminarProducto(String id) {
+        String r = useCase.eliminar(id);
+        if ("OK".equals(r)) cache.invalidate(CacheType.PRODUCTOS);
+        return r;
+    }
+
     public List<Categoria> listarCategorias() {
         return cache.get(CacheType.CATEGORIAS, () -> useCase.listarCategorias());
     }
 
     public int obtenerStockTotal(String sedeId, String productoId) {
         return stockUseCase.obtenerStockTotal(sedeId, productoId);
+    }
+
+    public boolean productoTieneLotes(String productoId) {
+        return stockUseCase.tieneLotes(productoId);
     }
 
     public Map<String, Integer> obtenerStockTotalPorSede(String sedeId) {

--- a/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcLoteRepository.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcLoteRepository.java
@@ -228,6 +228,23 @@ public class JdbcLoteRepository implements LoteRepository {
     }
 
     @Override
+    public boolean existsByProducto(String productoId) {
+        String sql = "SELECT COUNT(*) FROM lotes WHERE producto_id = ?";
+        try (Connection conn = dbConfig.getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, productoId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    return rs.getInt(1) > 0;
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        return false;
+    }
+
+    @Override
     public Lote save(Lote lote) {
         try (Connection conn = dbConfig.getConnection()) {
             return save(conn, lote);

--- a/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcProductoRepository.java
+++ b/src/main/java/com/utp/meditrackapp/infrastructure/persistence/jdbc/JdbcProductoRepository.java
@@ -149,6 +149,18 @@ public class JdbcProductoRepository implements ProductoRepository {
     }
 
     @Override
+    public void eliminar(String id) {
+        String sql = "DELETE FROM productos WHERE id = ?";
+        try (Connection conn = DatabaseConfig.getInstance().getConnection();
+             PreparedStatement ps = conn.prepareStatement(sql)) {
+            ps.setString(1, id);
+            ps.executeUpdate();
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
     public boolean existeCodigoDigemid(String codigoDigemid) {
         String sql = "SELECT COUNT(*) FROM productos WHERE codigo_digemid = ?";
         try (Connection conn = DatabaseConfig.getInstance().getConnection();

--- a/src/main/resources/com/utp/meditrackapp/productos-view.fxml
+++ b/src/main/resources/com/utp/meditrackapp/productos-view.fxml
@@ -65,7 +65,7 @@
                                 <TableColumn fx:id="colPrecio" text="PRECIO UNIT." prefWidth="100" />
                                 <TableColumn fx:id="colStock" text="STOCK ACTUAL" prefWidth="100" />
                                 <TableColumn fx:id="colEstado" text="ESTADO" prefWidth="100" />
-                                <TableColumn fx:id="colAcciones" text="ACCIONES" prefWidth="150" sortable="false" />
+                                <TableColumn fx:id="colAcciones" text="ACCIONES" prefWidth="120" minWidth="110" maxWidth="160" sortable="false" />
                             </columns>
                             <columnResizePolicy><TableView fx:constant="CONSTRAINED_RESIZE_POLICY" /></columnResizePolicy>
                             <placeholder>


### PR DESCRIPTION
- Add 3rd action button (permanent delete) alongside edit and deactivate
- Change deactivate icon from fas-trash to fas-toggle-off (warning style)
- Permanent delete uses fas-trash (danger style) with text confirmation
- Validate product has no lotes across ALL sedes before allowing deletion
- Add existsByProducto to LoteRepository chain (global check)
- Adjust colAcciones width (pref=120, min=110, max=160) for 3 buttons